### PR TITLE
Add version as query parameter in `POST` requests

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,17 +3,32 @@
 {% block content %}
     <div class="box">
         <h2>Senti-O-Meter</h2>
-        <form action="/submit" method="POST">
+        <form id="submitForm" action="/submit" method="POST">
             {{ review_form.csrf_token }}
             {{ review_form.review.label }}
             {{ review_form.review }}
             <input type="submit">
         </form>
+        <script>
+            // JavaScript code
+            document.getElementById('submitForm').addEventListener('submit', function(event) {
+              var current_version = "{{ current_version }}";
+          
+              // Get the form action URL
+              var formAction = this.getAttribute('action');
+          
+              // Modify the form action URL by appending the version query parameter
+              var updatedAction = formAction + "?version=" + encodeURIComponent(current_version);
+          
+              // Update the form action attribute
+              this.setAttribute('action', updatedAction);
+            });
+        </script>
         <div class="item">
             <h2>{{ smiley_emoji | safe }}</h2>
         </div>
         <div class="item">
-            <form action="/validate" method="POST">
+            <form id="validateForm" action="/validate" method="POST">
                 {{ validation_form.csrf_token }}
                 <div class="radio">
                     {% for option in validation_form.is_correct %}
@@ -27,6 +42,21 @@
                     <input type="submit">
                 {% endif %}
             </form>
+            <script>
+                // JavaScript code
+                document.getElementById('validateForm').addEventListener('submit', function(event) {
+                  var current_version = "{{ current_version }}";
+              
+                  // Get the form action URL
+                  var formAction = this.getAttribute('action');
+              
+                  // Modify the form action URL by appending the version query parameter
+                  var updatedAction = formAction + "?version=" + encodeURIComponent(current_version);
+              
+                  // Update the form action attribute
+                  this.setAttribute('action', updatedAction);
+                });
+            </script>
         </div>
         <div class="item">
             <h2>{{ current_version }}</h2>


### PR DESCRIPTION
Add the current version of the application as a query parameter to the `/submit` and `/validate` actions.

Now, if the user hits the "submit" button to submit a review, they essentially make a `POST` request to either `/submit?version=2.0.1` or `/submit?version=0.1.1`, depending on the version of the app that they're running (`0.1.1` for no emojis and `2.0.1` for emojis).

This `version` query parameter will help the Istio ingressgateway to route each `POST` request to the correct corresponding Pod. In a few words, we avoid sending `POST` requests that were meant for one version of the app to the wrong Pod.

_**IMPORTANT**_: After this is merged, we need to build and push (again) two images:
- ghcr.io/remla23-team06/app:with-emojis
- ghcr.io/remla23-team06/app:without-emojis
, so that they contain the updated logic for both with and without emoji versions.
